### PR TITLE
Split admin challenge edit and supervisor edit

### DIFF
--- a/app/controllers/admin/review_controller.rb
+++ b/app/controllers/admin/review_controller.rb
@@ -23,10 +23,7 @@ class Admin::ReviewController < Admin::AdminController
     @challenge = Challenge.find(params[:id])
     @url = admin_review_path(@challenge)
 
-    unless @challenge.editable_by_user?(current_user)
-      redirect_to @challenge, alert: "You do not have the permissions required to view this page."
-    end
-     render 'challenges/edit'
+    render 'challenges/edit'
   end
 
   def submit_for_review?
@@ -35,14 +32,10 @@ class Admin::ReviewController < Admin::AdminController
 
 
   def update
-    @challenge = Challenge.pending.find(params[:id])
+    @challenge = Challenge.find(params[:id])
 
-     if params[:challenge].present?
+    if params[:challenge].present?
       image = params[:challenge].delete :image
-    end
-
-    if self.submit_for_review?
-      @challenge.state = 'pending'
     end
 
     if image.present?
@@ -50,8 +43,7 @@ class Admin::ReviewController < Admin::AdminController
     end
 
     if @challenge.update_attributes(params[:challenge])
-
-      redirect_to admin_review_path(@challenge), notice: 'Challenge was successfully updated.'
+      redirect_to edit_admin_review_path(@challenge), notice: 'Challenge was successfully updated.'
     else
       render action: "edit"
     end

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -62,6 +62,9 @@ class ChallengesController < ApplicationController
   def edit
     @challenge =  Challenge.find(params[:id])
 
+    # Admins have their own edit options; this is for mortals only
+    redirect_to edit_admin_review_path(@challenge) and return if current_user.is_admin?
+
     unless @challenge.editable_by_user?(current_user)
       redirect_to @challenge, alert: "You do not have the permissions required to view this page."
     end

--- a/app/views/shared/_form.html.haml
+++ b/app/views/shared/_form.html.haml
@@ -54,5 +54,8 @@
           = f.text_field :commitment, :placeholder => "Challenge commitment... ", :class => "enable-popover", "data-toggle" => "popover", "data-placement" => "right", "data-trigger" => "focus", "data-content" => "What is the minimal number of hours per week a student should commit to this challenge?", :title => "Challenge Commitment"
       .control-group
         .controls
-          = f.submit 'Save draft', :class => "btn"
-          = f.submit submit_resubmit_name(@challenge), :class => "btn btn-primary", :confirm => "You are submitting your challenge for review, continue?"
+          -if current_user.is_admin?
+            = f.submit "Save challenge", :class => "btn btn-primary", :confirm => "You are using sudo magic, continue?"
+          -else
+            = f.submit 'Save draft', :class => "btn"
+            = f.submit submit_resubmit_name(@challenge), :class => "btn btn-primary", :confirm => "You are submitting your challenge for review, continue?"


### PR DESCRIPTION
Admins now only have their own edit screen, and the edit screen for mortals redirects to that one (except if you're a supervisor, of course).
